### PR TITLE
Fix pointer events for Neon Dash overlay

### DIFF
--- a/neon_dash/js/game.js
+++ b/neon_dash/js/game.js
@@ -31,6 +31,9 @@ let bossObj = null; let bossTimer = 0;
 export function showOverlay(html){
   overlay.innerHTML = html;
   overlay.style.display = 'flex';
+  // Ensure the overlay can receive pointer events even if the
+  // style was modified elsewhere at runtime.
+  overlay.style.pointerEvents = 'auto';
 }
 
 export function createPlayer(){


### PR DESCRIPTION
## Summary
- ensure overlay always accepts pointer events when displayed

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685fe5d547c08326942fd471454bed5d