### PR TITLE
Add debug logs for shop button

### DIFF
--- a/neon_dash/js/game.js
+++ b/neon_dash/js/game.js
@@ -29,11 +29,14 @@ const LEVEL_TIME = 22;
 let bossObj = null; let bossTimer = 0;
 
 export function showOverlay(html){
+  console.log('showOverlay called');
+  console.log('overlay html:', html);
   overlay.innerHTML = html;
   overlay.style.display = 'flex';
   // Ensure the overlay can receive pointer events even if the
   // style was modified elsewhere at runtime.
   overlay.style.pointerEvents = 'auto';
+  console.log('overlay pointer events after showOverlay:', overlay.style.pointerEvents);
 }
 
 export function createPlayer(){
@@ -41,6 +44,7 @@ export function createPlayer(){
 }
 
 export function startGame(){
+  console.log('startGame called');
   score = 0; speed = 4; frame = 0; moneyThisRun = 0;
   player = createPlayer();
   obstacles = []; orbs = [];

--- a/neon_dash/js/main.js
+++ b/neon_dash/js/main.js
@@ -1,6 +1,8 @@
 import { startGame, showOverlay } from './game.js';
 import { showShop } from './shop.js';
 
+console.log('main.js loaded');
+
 window.startGame = startGame;
 window.showShop = showShop;
 

--- a/neon_dash/js/shop.js
+++ b/neon_dash/js/shop.js
@@ -4,6 +4,7 @@ import { showOverlay, startGame } from './game.js';
 let shopTab = 'skins';
 
 export function showShop(tab){
+  console.log('showShop called with tab:', tab);
   shopTab = tab || shopTab || 'skins';
   let html = `
     <div class="shop-title">SHOP</div>
@@ -106,7 +107,12 @@ export function showShop(tab){
       }
     }
     const playBtn = document.getElementById('shop-play-btn');
-    if(playBtn) playBtn.onclick = () => startGame();
+    if(playBtn){
+      console.log('Play button found, attaching click handler');
+      playBtn.onclick = () => startGame();
+    } else {
+      console.log('Play button not found');
+    }
   },30);
 }
 


### PR DESCRIPTION
## Summary
- add diagnostic logs to track overlay state and play button setup
- log script load and shop tab info for debugging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fe866fd4c832681785ad7c080b099