### PR TITLE
Add game state logging and fix start state

### DIFF
--- a/neon_dash/js/game.js
+++ b/neon_dash/js/game.js
@@ -29,11 +29,19 @@ const LEVEL_TIME = 22;
 let bossObj = null; let bossTimer = 0;
 
 export function showOverlay(html){
+  console.log('showOverlay called');
+  console.log('overlay html:', html);
   overlay.innerHTML = html;
   overlay.style.display = 'flex';
   // Ensure the overlay can receive pointer events even if the
   // style was modified elsewhere at runtime.
   overlay.style.pointerEvents = 'auto';
+  console.log('overlay pointer events after showOverlay:', overlay.style.pointerEvents);
+}
+
+export function setGameState(state){
+  gameState = state;
+  console.log('setGameState:', gameState);
 }
 
 export function createPlayer(){
@@ -41,6 +49,8 @@ export function createPlayer(){
 }
 
 export function startGame(){
+  console.log('startGame called');
+  setGameState('playing');
   score = 0; speed = 4; frame = 0; moneyThisRun = 0;
   player = createPlayer();
   obstacles = []; orbs = [];
@@ -348,6 +358,6 @@ window.addEventListener('keyup', e => {
   if(e.key==='ArrowDown') input.down=false;
 });
 
-export { tryShout, tryDash, trySlowmo };
+export { tryShout, tryDash, trySlowmo, setGameState };
 
 requestAnimationFrame(loop);

--- a/neon_dash/js/main.js
+++ b/neon_dash/js/main.js
@@ -1,6 +1,8 @@
 import { startGame, showOverlay } from './game.js';
 import { showShop } from './shop.js';
 
+console.log('main.js loaded');
+
 window.startGame = startGame;
 window.showShop = showShop;
 

--- a/neon_dash/js/shop.js
+++ b/neon_dash/js/shop.js
@@ -1,10 +1,13 @@
 import { SKINS, UPGRADES, PETS, saveData, saveGame } from './data.js';
-import { showOverlay, startGame } from './game.js';
+import { showOverlay, startGame, setGameState } from './game.js';
 
 let shopTab = 'skins';
 
 export function showShop(tab){
+  console.log('showShop called with tab:', tab);
   shopTab = tab || shopTab || 'skins';
+  setGameState('shop');
+  console.log('gameState after showShop:', 'shop');
   let html = `
     <div class="shop-title">SHOP</div>
     <div class="shop-tabs">
@@ -106,7 +109,12 @@ export function showShop(tab){
       }
     }
     const playBtn = document.getElementById('shop-play-btn');
-    if(playBtn) playBtn.onclick = () => startGame();
+    if(playBtn){
+      console.log('Play button found, attaching click handler');
+      playBtn.onclick = () => startGame();
+    } else {
+      console.log('Play button not found');
+    }
   },30);
 }
 


### PR DESCRIPTION
## Summary
- ensure startGame and showShop set `gameState`
- add `setGameState` helper with logging
- use new helper to avoid infinite overlay updates

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685fe866fd4c832681785ad7c080b099