### PR TITLE
Fix duplicate export in neon_dash

### DIFF
--- a/neon_dash/js/game.js
+++ b/neon_dash/js/game.js
@@ -361,6 +361,7 @@ window.addEventListener('keyup', e => {
   if(e.key==='ArrowDown') input.down=false;
 });
 
-export { tryShout, tryDash, trySlowmo, setGameState };
+// Export gameplay utility functions for other modules
+export { tryShout, tryDash, trySlowmo };
 
 requestAnimationFrame(loop);


### PR DESCRIPTION
## Summary
- avoid exporting `setGameState` twice in `neon_dash/js/game.js`

## Testing
- `grep -n "Export gameplay" -n -n neon_dash/js/game.js`

------
https://chatgpt.com/codex/tasks/task_e_685fedae8e708326bea54ccb81b91f6b